### PR TITLE
Don't set isPurchased to false on every edit

### DIFF
--- a/pages/api/gifts/edit/index.js
+++ b/pages/api/gifts/edit/index.js
@@ -27,7 +27,6 @@ export default async function editGift(req, res) {
                 name: data.name,
                 description: data.description,
                 url: data.url,
-                isPurchased: false,
                 owner: session.user.email,
                 giftFor: {
                   name: data.giftFor ? data.giftFor : session.user.name,


### PR DESCRIPTION
This fixes an issue where I was setting `isPurchased` to false on every gift edit.