### PR TITLE
Add environment-based table name configuration

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -8,3 +8,16 @@ if (!supabaseUrl || !supabaseKey) {
 }
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
+
+/**
+ * Returns the appropriate table name based on the environment.
+ * In production, uses the original table name.
+ * In development, prefixes the table name with "dev_".
+ *
+ * @param {string} tableName - The base table name
+ * @returns {string} The environment-specific table name
+ */
+export function getTableName(tableName) {
+  const isProduction = process.env.NODE_ENV === 'production';
+  return isProduction ? tableName : `dev_${tableName}`;
+}

--- a/pages/api/gifts/[groupId].js
+++ b/pages/api/gifts/[groupId].js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../lib/supabase";
+import { supabase, getTableName } from "../../../lib/supabase";
 import { authOptions } from "../auth/[...nextauth]";
 
 export default async function getGiftsByGroup(req, res) {
@@ -19,7 +19,7 @@ export default async function getGiftsByGroup(req, res) {
     } = req;
 
     const { data: gifts, error } = await supabase
-      .from("gifts")
+      .from(getTableName("gifts"))
       .select(
         "id, name, description, url, is_purchased, purchased_by, image_url, price, gift_for_name, owner",
       )

--- a/pages/api/gifts/create/index.js
+++ b/pages/api/gifts/create/index.js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../../lib/supabase";
+import { supabase, getTableName } from "../../../../lib/supabase";
 import { authOptions } from "../../auth/[...nextauth]";
 
 export default async function createGift(req, res) {
@@ -21,7 +21,7 @@ export default async function createGift(req, res) {
     const data = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
 
     const { data: gift, error } = await supabase
-      .from("gifts")
+      .from(getTableName("gifts"))
       .insert({
         name: data.name,
         description: data.description,

--- a/pages/api/gifts/delete/index.js
+++ b/pages/api/gifts/delete/index.js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../../lib/supabase";
+import { supabase, getTableName } from "../../../../lib/supabase";
 import { errorMessages } from "../../../../lib/constants";
 import { authOptions } from "../../auth/[...nextauth]";
 
@@ -27,7 +27,7 @@ export default async function deleteGift(req, res) {
 
     // First, check to make sure the user can delete this gift
     const { data: gift, error: fetchError } = await supabase
-      .from("gifts")
+      .from(getTableName("gifts"))
       .select("owner")
       .eq("id", giftId)
       .single();
@@ -39,7 +39,7 @@ export default async function deleteGift(req, res) {
 
     if (gift && gift.owner === email) {
       const { error: deleteError } = await supabase
-        .from("gifts")
+        .from(getTableName("gifts"))
         .delete()
         .eq("id", giftId);
 

--- a/pages/api/gifts/edit/index.js
+++ b/pages/api/gifts/edit/index.js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../../lib/supabase";
+import { supabase, getTableName } from "../../../../lib/supabase";
 import { errorMessages } from "../../../../lib/constants";
 import { authOptions } from "../../auth/[...nextauth]";
 
@@ -26,7 +26,7 @@ export default async function editGift(req, res) {
 
     // First, check if the user is the owner
     const { data: gift, error: fetchError } = await supabase
-      .from("gifts")
+      .from(getTableName("gifts"))
       .select("owner")
       .eq("id", data.giftId)
       .single();
@@ -38,7 +38,7 @@ export default async function editGift(req, res) {
 
     if (gift && gift.owner === email) {
       const { data: updatedGift, error: updateError } = await supabase
-        .from("gifts")
+        .from(getTableName("gifts"))
         .update({
           name: data.name,
           description: data.description,

--- a/pages/api/gifts/purchase/index.js
+++ b/pages/api/gifts/purchase/index.js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../../lib/supabase";
+import { supabase, getTableName } from "../../../../lib/supabase";
 import { errorMessages } from "../../../../lib/constants";
 import { authOptions } from "../../auth/[...nextauth]";
 
@@ -29,7 +29,7 @@ export default async function purchaseGift(req, res) {
 
     // Query groups where the user is in the members array
     const { data: groups, error: groupsError } = await supabase
-      .from("groups")
+      .from(getTableName("groups"))
       .select("id")
       .contains("members", [email]);
 
@@ -48,7 +48,7 @@ export default async function purchaseGift(req, res) {
 
     if (isMember) {
       const { data: updatedGift, error: updateError } = await supabase
-        .from("gifts")
+        .from(getTableName("gifts"))
         .update({
           is_purchased: data.isPurchased,
           purchased_by: data.isPurchased ? email : null,

--- a/pages/api/groups/[groupId].js
+++ b/pages/api/groups/[groupId].js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../lib/supabase";
+import { supabase, getTableName } from "../../../lib/supabase";
 import { errorMessages } from "../../../lib/constants";
 import { authOptions } from "../auth/[...nextauth]";
 
@@ -23,7 +23,7 @@ export default async function getGroup(req, res) {
     } = req;
 
     const { data: group, error } = await supabase
-      .from("groups")
+      .from(getTableName("groups"))
       .select("id, name, description, owner, members")
       .eq("id", groupId)
       .single();

--- a/pages/api/groups/create/index.js
+++ b/pages/api/groups/create/index.js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../../lib/supabase";
+import { supabase, getTableName } from "../../../../lib/supabase";
 import { authOptions } from "../../auth/[...nextauth]";
 
 export default async function createGroup(req, res) {
@@ -20,7 +20,7 @@ export default async function createGroup(req, res) {
     const data = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
 
     const { data: group, error } = await supabase
-      .from("groups")
+      .from(getTableName("groups"))
       .insert({
         name: data.name,
         description: data.description,

--- a/pages/api/groups/edit/index.js
+++ b/pages/api/groups/edit/index.js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../../lib/supabase";
+import { supabase, getTableName } from "../../../../lib/supabase";
 import { errorMessages } from "../../../../lib/constants";
 import { authOptions } from "../../auth/[...nextauth]";
 
@@ -26,7 +26,7 @@ export default async function editGroup(req, res) {
 
     // First, check if the user is the owner
     const { data: group, error: fetchError } = await supabase
-      .from("groups")
+      .from(getTableName("groups"))
       .select("owner")
       .eq("id", data.groupId)
       .single();
@@ -38,7 +38,7 @@ export default async function editGroup(req, res) {
 
     if (group && group.owner === email) {
       const { data: updatedGroup, error: updateError } = await supabase
-        .from("groups")
+        .from(getTableName("groups"))
         .update({
           name: data.name,
           description: data.description,

--- a/pages/api/groups/index.js
+++ b/pages/api/groups/index.js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../lib/supabase";
+import { supabase, getTableName } from "../../../lib/supabase";
 import { authOptions } from "../auth/[...nextauth]";
 
 export default async function groupsApi(req, res) {
@@ -25,7 +25,7 @@ export default async function groupsApi(req, res) {
 
     // Query groups where the user is in the members array
     const { data: groups, error } = await supabase
-      .from("groups")
+      .from(getTableName("groups"))
       .select("id, name, description")
       .contains("members", [email]);
 

--- a/pages/api/groups/join/index.js
+++ b/pages/api/groups/join/index.js
@@ -1,5 +1,5 @@
 import { unstable_getServerSession } from "next-auth/next";
-import { supabase } from "../../../../lib/supabase";
+import { supabase, getTableName } from "../../../../lib/supabase";
 import { authOptions } from "../../auth/[...nextauth]";
 
 export default async function groupsApi(req, res) {
@@ -26,7 +26,7 @@ export default async function groupsApi(req, res) {
 
     // First, fetch the group
     const { data: group, error: fetchError } = await supabase
-      .from("groups")
+      .from(getTableName("groups"))
       .select("members")
       .eq("id", groupId)
       .single();
@@ -42,7 +42,7 @@ export default async function groupsApi(req, res) {
     } else {
       // Add user to members array
       const { data: updatedGroup, error: updateError } = await supabase
-        .from("groups")
+        .from(getTableName("groups"))
         .update({ members: [...group.members, email] })
         .eq("id", groupId)
         .select()


### PR DESCRIPTION
Updates the application to use different database tables based on the environment:
- Production mode (NODE_ENV=production): Uses standard tables (groups, gifts)
- Development mode (NODE_ENV!=production): Uses dev-prefixed tables (dev_groups, dev_gifts)

Changes:
- Added getTableName() helper function in lib/supabase.js
- Updated all API routes to use getTableName() instead of hardcoded table names
- Modified routes: groups, gifts endpoints (index, create, edit, delete, join, purchase)

This allows safe development testing without affecting production data.