### PR TITLE
Add group delete feature for owners

### DIFF
--- a/components/Groups/GroupHeader.js
+++ b/components/Groups/GroupHeader.js
@@ -1,10 +1,12 @@
 import { useForm } from "react-hook-form";
 import { useState } from "react";
+import { useRouter } from "next/router";
 import TextInputControl from "../Forms/TextInputControl";
 import { borderColors } from "../../lib/accentColors";
 import { getRandomInt } from "../../lib/randomInt";
 
 const GroupHeader = ({ name, description, isOwner, id, editedCallback }) => {
+  const router = useRouter();
   const randomColor = borderColors[getRandomInt(0, 5)];
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -49,8 +51,30 @@ const GroupHeader = ({ name, description, isOwner, id, editedCallback }) => {
     setIsDeleting(!isDeleting);
   };
 
-  const handleGroupDelete = () => {
-    console.log("deleting the group");
+  const handleGroupDelete = async () => {
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch("/api/groups/delete", {
+        method: "DELETE",
+        body: JSON.stringify({ groupId: id }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok && result.data.message === "Success") {
+        // Redirect to groups list page after successful deletion
+        router.push("/groups");
+      } else {
+        console.error("Failed to delete group:", result);
+        alert("Failed to delete group. Please try again.");
+      }
+    } catch (error) {
+      console.error("Error deleting group:", error);
+      alert("An error occurred while deleting the group.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleGroupSave = () => {
@@ -133,26 +157,37 @@ const GroupHeader = ({ name, description, isOwner, id, editedCallback }) => {
               <button
                 className="mr-3 bg-gray-200 dark:bg-gray-700 focus:outline-none transition duration-150 ease-in-out rounded hover:bg-gray-300 text-blue-700 dark:hover:bg-gray-600 dark:text-blue-600 px-5 py-2 text-sm"
                 onClick={handleGroupDeleteToggle}
+                disabled={isSubmitting}
               >
                 Cancel
               </button>
               <button
-                className="bg-red-500 dark:bg-red-700 focus:outline-none transition duration-150 ease-in-out rounded hover:bg-red-700 text-white dark:hover:bg-gray-600 dark:text-gray-200 px-5 py-2 text-sm"
+                className="bg-red-500 dark:bg-red-700 focus:outline-none transition duration-150 ease-in-out rounded hover:bg-red-700 text-white dark:hover:bg-gray-600 dark:text-gray-200 px-5 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={handleGroupDelete}
+                disabled={isSubmitting}
               >
-                Delete
+                {isSubmitting ? "Deleting..." : "Delete"}
               </button>
             </div>
           )}
           {!isDeleting && !isEditing && (
             <div className="mt-6 md:mt-0">
               {isOwner && (
-                <button
-                  className="transition focus:outline-none duration-150 ease-in-out hover:bg-blue-600 bg-blue-700 rounded text-white px-8 py-2 text-sm"
-                  onClick={handleEditToggle}
-                >
-                  Edit
-                </button>
+                <>
+                  <button
+                    className="mr-3 bg-red-500 dark:bg-red-700 focus:outline-none transition duration-150 ease-in-out rounded hover:bg-red-700 text-white dark:hover:bg-red-800 dark:text-gray-200 px-5 py-2 text-sm"
+                    onClick={handleGroupDeleteToggle}
+                    type="button"
+                  >
+                    Delete
+                  </button>
+                  <button
+                    className="transition focus:outline-none duration-150 ease-in-out hover:bg-blue-600 bg-blue-700 rounded text-white px-8 py-2 text-sm"
+                    onClick={handleEditToggle}
+                  >
+                    Edit
+                  </button>
+                </>
               )}
             </div>
           )}

--- a/components/Groups/GroupHeader.test.js
+++ b/components/Groups/GroupHeader.test.js
@@ -100,4 +100,138 @@ describe('GroupHeader', () => {
     const heading = screen.getByText('Test Group');
     expect(heading).toHaveClass('mb-2', 'text-4xl', 'font-extrabold');
   });
+
+  describe('Delete functionality', () => {
+    it('renders Delete button when user is owner', () => {
+      render(<GroupHeader {...mockProps} />);
+      const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      expect(deleteButtons[0]).toBeInTheDocument();
+    });
+
+    it('does not render Delete button when user is not owner', () => {
+      render(<GroupHeader {...mockProps} isOwner={false} />);
+      expect(screen.queryByRole('button', { name: /Delete/i })).not.toBeInTheDocument();
+    });
+
+    it('shows confirmation dialog when Delete button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<GroupHeader {...mockProps} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      await user.click(deleteButtons[0]);
+
+      expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+    });
+
+    it('hides confirmation dialog when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(<GroupHeader {...mockProps} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      await user.click(deleteButtons[0]);
+
+      expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+      expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+    });
+
+    it('calls delete API and redirects on successful deletion', async () => {
+      const user = userEvent.setup();
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { message: 'Success' } }),
+      });
+
+      render(<GroupHeader {...mockProps} />);
+
+      // Click first delete button to show confirmation
+      const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      await user.click(deleteButtons[0]);
+
+      // Click confirm delete button
+      const confirmDeleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      const confirmButton = confirmDeleteButtons.find(btn =>
+        btn.className.includes('bg-red-500')
+      );
+      await user.click(confirmButton);
+
+      // Wait for fetch to be called
+      await vi.waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/groups/delete', {
+          method: 'DELETE',
+          body: JSON.stringify({ groupId: 'group-123' }),
+        });
+      });
+
+      // Wait for redirect
+      await vi.waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/groups');
+      });
+    });
+
+    it('shows error alert when deletion fails', async () => {
+      const user = userEvent.setup();
+      const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: 'Failed to delete' }),
+      });
+
+      render(<GroupHeader {...mockProps} />);
+
+      // Click first delete button to show confirmation
+      const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      await user.click(deleteButtons[0]);
+
+      // Click confirm delete button
+      const confirmDeleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      const confirmButton = confirmDeleteButtons.find(btn =>
+        btn.className.includes('bg-red-500')
+      );
+      await user.click(confirmButton);
+
+      await vi.waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith('Failed to delete group. Please try again.');
+      }, { timeout: 2000 });
+
+      alertSpy.mockRestore();
+    });
+
+    it('shows loading state during deletion', async () => {
+      const user = userEvent.setup();
+
+      global.fetch = vi.fn().mockImplementation(() =>
+        new Promise(resolve => setTimeout(() => resolve({
+          ok: true,
+          json: async () => ({ data: { message: 'Success' } }),
+        }), 500))
+      );
+
+      render(<GroupHeader {...mockProps} />);
+
+      // Click first delete button to show confirmation
+      const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      await user.click(deleteButtons[0]);
+
+      // Click confirm delete button
+      const confirmDeleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+      const confirmButton = confirmDeleteButtons.find(btn =>
+        btn.className.includes('bg-red-500')
+      );
+
+      // Click and immediately check for loading state
+      const clickPromise = user.click(confirmButton);
+
+      // Wait for the loading state to appear
+      await vi.waitFor(() => {
+        expect(screen.getByText('Deleting...')).toBeInTheDocument();
+      }, { timeout: 1000 });
+
+      await clickPromise;
+    });
+  });
 });

--- a/components/Groups/GroupHeader.test.js
+++ b/components/Groups/GroupHeader.test.js
@@ -3,6 +3,17 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GroupHeader from './GroupHeader';
 
+// Mock Next.js router
+const mockPush = vi.fn();
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
 // Mock dependencies
 vi.mock('../../lib/accentColors', () => ({
   borderColors: ['border-blue-500', 'border-red-500', 'border-green-500', 'border-yellow-500', 'border-purple-500', 'border-pink-500'],
@@ -23,6 +34,7 @@ describe('GroupHeader', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPush.mockClear();
     global.fetch = vi.fn();
   });
 

--- a/pages/api/groups/delete/index.js
+++ b/pages/api/groups/delete/index.js
@@ -1,0 +1,64 @@
+import { unstable_getServerSession } from "next-auth/next";
+import { supabase, getTableName } from "../../../../lib/supabase";
+import { errorMessages } from "../../../../lib/constants";
+import { authOptions } from "../../auth/[...nextauth]";
+
+export default async function deleteGroup(req, res) {
+  const session = await unstable_getServerSession(req, res, authOptions);
+
+  if (!session) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { user } = session;
+  const { email } = user;
+
+  if (req.method !== "DELETE") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const data = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+
+    if (!data.groupId) {
+      return res.status(400).json({ error: "Group ID is required" });
+    }
+
+    // First, check if the user is the owner
+    const { data: group, error: fetchError } = await supabase
+      .from(getTableName("groups"))
+      .select("owner")
+      .eq("id", data.groupId)
+      .single();
+
+    if (fetchError) {
+      console.error("Error fetching group:", fetchError);
+      return res.status(500).json({ error: fetchError.message });
+    }
+
+    if (group && group.owner === email) {
+      // Delete the group
+      const { error: deleteError } = await supabase
+        .from(getTableName("groups"))
+        .delete()
+        .eq("id", data.groupId);
+
+      if (deleteError) {
+        console.error("Error deleting group:", deleteError);
+        return res.status(500).json({ error: deleteError.message });
+      }
+
+      return res
+        .status(200)
+        .json({ data: { message: "Success" } });
+    } else {
+      console.log(`Unauthorized user ${email} trying to delete ${data.groupId}.`);
+
+      // return unauthorized if the current user isn't the owner of this group
+      return res.status(401).json({ message: errorMessages.unAuthorizedUser });
+    }
+  } catch (error) {
+    console.error("Error:", error);
+    return res.status(500).json({ error: error.message });
+  }
+}


### PR DESCRIPTION
- Created DELETE API endpoint at /api/groups/delete with owner authorization
- Added delete button to GroupHeader component (visible only to group owner)
- Implemented confirmation dialog before deletion
- Added loading state during deletion process
- Redirects to groups list page after successful deletion
- Authorization check ensures only group owners can delete their groups