### PR TITLE
Add loading indicator to gift form during submission

### DIFF
--- a/components/Gifts/CreateGift.js
+++ b/components/Gifts/CreateGift.js
@@ -62,6 +62,10 @@ const CreateGift = ({ updated }) => {
             + Gift
           </button>
         </div>
+      ) : isSubmitting ? (
+        <div className="text-center h-full flex flex-col justify-center">
+          <p className="text-lg">Adding gift...</p>
+        </div>
       ) : (
         <>
           <h2 className="mb-4 font-bold text-lg">Add a Gift</h2>
@@ -106,7 +110,7 @@ const CreateGift = ({ updated }) => {
             />
 
             <div className="mt-4 flex justify-evenly">
-              <Button type="submit">Submit {isSubmitting && "..."}</Button>
+              <Button type="submit">Submit</Button>
               <Button type="button" onClick={() => setIsEditing(false)}>
                 Cancel
               </Button>


### PR DESCRIPTION
- Show "Adding gift..." message instead of form while submitting
- Remove "..." from Submit button in favor of dedicated loading state
- Form already resets after successful submission, allowing user to add another gift