### PR TITLE
Migrate from SWR to TanStack React Query

### DIFF
--- a/components/Gifts/GiftsList.test.tsx
+++ b/components/Gifts/GiftsList.test.tsx
@@ -12,9 +12,12 @@ vi.mock("next/router", () => ({
   useRouter: vi.fn(),
 }));
 
-// Mock SWR
-vi.mock("swr", () => ({
-  default: vi.fn(),
+// Mock React Query
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+  useQueryClient: vi.fn(() => ({
+    invalidateQueries: vi.fn(),
+  })),
 }));
 
 // Mock child components
@@ -50,7 +53,7 @@ vi.mock("../Search/SearchForm", () => ({
   ),
 }));
 
-import useSWR from "swr";
+import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 import GiftsList from "./GiftsList";
 
@@ -68,10 +71,11 @@ describe("GiftsList", () => {
   });
 
   it("shows loading message when data is not loaded", () => {
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: undefined,
-      mutate: mockMutate,
+      refetch: mockMutate,
       error: undefined,
+      isLoading: true,
     });
 
     render(<GiftsList groupId="group-123" />);
@@ -79,10 +83,11 @@ describe("GiftsList", () => {
   });
 
   it("shows error message when there is an error", () => {
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: undefined,
-      mutate: mockMutate,
+      refetch: mockMutate,
       error: new Error("Failed to fetch"),
+      isLoading: false,
     });
 
     render(<GiftsList groupId="group-123" />);
@@ -92,10 +97,11 @@ describe("GiftsList", () => {
   });
 
   it("renders CreateGift component", () => {
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: { gifts: [] },
-      mutate: mockMutate,
+      refetch: mockMutate,
       error: undefined,
+      isLoading: false,
     });
 
     render(<GiftsList groupId="group-123" />);
@@ -124,10 +130,11 @@ describe("GiftsList", () => {
       },
     ];
 
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: { gifts: mockGifts },
-      mutate: mockMutate,
+      refetch: mockMutate,
       error: undefined,
+      isLoading: false,
     });
 
     render(<GiftsList groupId="group-123" />);
@@ -139,10 +146,11 @@ describe("GiftsList", () => {
   });
 
   it("applies grid layout classes", () => {
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: { gifts: [] },
-      mutate: mockMutate,
+      refetch: mockMutate,
       error: undefined,
+      isLoading: false,
     });
 
     const { container } = render(<GiftsList groupId="group-123" />);
@@ -187,10 +195,11 @@ describe("GiftsList", () => {
     ];
 
     beforeEach(() => {
-      (useSWR as any).mockReturnValue({
+      (useQuery as any).mockReturnValue({
         data: { gifts: mockGifts },
-        mutate: mockMutate,
+        refetch: mockMutate,
         error: undefined,
+        isLoading: false,
       });
     });
 
@@ -441,10 +450,11 @@ describe("GiftsList", () => {
       },
     ];
 
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: { gifts: mockGifts },
-      mutate: mockMutate,
+      refetch: mockMutate,
       error: undefined,
+      isLoading: false,
     });
 
     render(<GiftsList groupId="group-123" />);

--- a/components/Gifts/GiftsList.tsx
+++ b/components/Gifts/GiftsList.tsx
@@ -1,4 +1,4 @@
-import useSWR from "swr";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/router";
 import GiftCard from "./GiftCard";
@@ -47,12 +47,18 @@ const isGiftFilteringEnabled =
 
 const GiftsList = ({ groupId, initialSearch }: GiftsListProps) => {
   const router = useRouter();
-  const { data, mutate, error } = useSWR<GiftsData>(
-    `/api/gifts/${groupId}`,
-    fetcher,
-  );
+  const queryClient = useQueryClient();
+  const { data, error, refetch } = useQuery<GiftsData>({
+    queryKey: ["gifts", groupId],
+    queryFn: () => fetcher(`/api/gifts/${groupId}`),
+  });
   const [gifts, setGifts] = useState<Gift[]>([]);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  // Create a refetch function that can be passed to child components
+  const mutate = useCallback(() => {
+    refetch();
+  }, [refetch]);
 
   if (error) {
     return <p>Sorry. There was an error retrieving the gifts.</p>;

--- a/components/Groups/GroupsList.test.tsx
+++ b/components/Groups/GroupsList.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import GroupsList from "./GroupsList";
 
-// Mock SWR
-vi.mock("swr", () => ({
-  default: vi.fn(),
+// Mock React Query
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
 }));
 
 // Mock GroupCard
@@ -12,7 +12,7 @@ vi.mock("./GroupCard", () => ({
   default: ({ name }: any) => <div data-testid="group-card">{name}</div>,
 }));
 
-import useSWR from "swr";
+import { useQuery } from "@tanstack/react-query";
 
 describe("GroupsList", () => {
   beforeEach(() => {
@@ -20,9 +20,10 @@ describe("GroupsList", () => {
   });
 
   it("shows loading message when data is not loaded", () => {
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: undefined,
       error: undefined,
+      isLoading: true,
     });
 
     render(<GroupsList />);
@@ -30,9 +31,10 @@ describe("GroupsList", () => {
   });
 
   it("shows error message when there is an error", () => {
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: undefined,
       error: new Error("Failed to fetch"),
+      isLoading: false,
     });
 
     render(<GroupsList />);
@@ -45,9 +47,10 @@ describe("GroupsList", () => {
       { id: "2", name: "Group 2", description: "Desc 2" },
     ];
 
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: { data: mockGroups },
       error: undefined,
+      isLoading: false,
     });
 
     render(<GroupsList />);
@@ -56,9 +59,10 @@ describe("GroupsList", () => {
   });
 
   it("applies grid layout classes", () => {
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: { data: [] },
       error: undefined,
+      isLoading: false,
     });
 
     const { container } = render(<GroupsList />);
@@ -67,9 +71,10 @@ describe("GroupsList", () => {
   });
 
   it("renders no groups when data is empty", () => {
-    (useSWR as any).mockReturnValue({
+    (useQuery as any).mockReturnValue({
       data: { data: [] },
       error: undefined,
+      isLoading: false,
     });
 
     render(<GroupsList />);

--- a/components/Groups/GroupsList.tsx
+++ b/components/Groups/GroupsList.tsx
@@ -1,4 +1,4 @@
-import useSWR from "swr";
+import { useQuery } from "@tanstack/react-query";
 import GroupCard from "./GroupCard";
 
 interface Group {
@@ -15,10 +15,13 @@ const fetcher = (url: string): Promise<GroupsResponse> =>
   fetch(url).then((res) => res.json());
 
 const GroupsList = () => {
-  const { data: groupData, error } = useSWR<GroupsResponse>("/api/groups", fetcher);
+  const { data: groupData, error, isLoading } = useQuery<GroupsResponse>({
+    queryKey: ["groups"],
+    queryFn: () => fetcher("/api/groups"),
+  });
 
   if (error) return "An error has occurred.";
-  if (!groupData) return "Loading..."; // todo create a better loading component here
+  if (isLoading || !groupData) return "Loading..."; // todo create a better loading component here
 
   const { data: groups } = groupData;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@supabase/supabase-js": "^2.78.0",
+        "@tanstack/react-query": "^5.90.7",
+        "@tanstack/react-query-devtools": "^5.90.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^1.2.1",
         "lucide-react": "^0.552.0",
@@ -22,7 +24,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.66.0",
-        "swr": "^2.3.6",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -2919,6 +2920,59 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.7.tgz",
+      "integrity": "sha512-6PN65csiuTNfBMXqQUxQhCNdtm1rV+9kC9YwWAIKcaxAauq3Wu7p18j3gQY3YIBJU70jT/wzCCZ2uqto/vQgiQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.90.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
+      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.7.tgz",
+      "integrity": "sha512-wAHc/cgKzW7LZNFloThyHnV/AX9gTg3w5yAv0gvQHPZoCnepwqCMtzbuPbb2UvfvO32XZ46e8bPOYbfZhzVnnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
+      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.90.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.2",
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3626,6 +3680,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5114,18 +5169,6 @@
         }
       }
     },
-    "node_modules/swr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
-      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -5298,14 +5341,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@supabase/supabase-js": "^2.78.0",
+    "@tanstack/react-query": "^5.90.7",
+    "@tanstack/react-query-devtools": "^5.90.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",
     "lucide-react": "^0.552.0",
@@ -31,7 +33,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.66.0",
-    "swr": "^2.3.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,18 +3,38 @@ import { SessionProvider } from "next-auth/react";
 import Head from "next/head";
 import Layout from "../components/Layout/Layout";
 import type { AppProps } from "next/app";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState } from "react";
 
 function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  // Create a client instance once per app instance
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            retry: 1,
+            staleTime: 5000,
+          },
+        },
+      })
+  );
+
   return (
     <>
       <Head>
         <title>WishGift</title>
       </Head>
-      <SessionProvider session={session}>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
-      </SessionProvider>
+      <QueryClientProvider client={queryClient}>
+        <SessionProvider session={session}>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        </SessionProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
     </>
   );
 }

--- a/pages/groups/[groupId].tsx
+++ b/pages/groups/[groupId].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 import { signIn } from "next-auth/react";
-import useSWR from "swr";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
 import GroupHeader from "../../components/Groups/GroupHeader";
 import GiftsList from "../../components/Gifts/GiftsList";
 import { errorMessages } from "../../lib/constants";
@@ -44,10 +45,16 @@ const fetcher = async (url: string): Promise<GroupData> => {
 const GroupPage: NextPage = () => {
   const { query } = useRouter();
   const endpoint = query.groupId ? `/api/groups/${query.groupId}` : "";
-  const { data, error, mutate } = useSWR<GroupData, FetchError>(
-    endpoint,
-    fetcher,
-  );
+  const { data, error, refetch } = useQuery<GroupData, FetchError>({
+    queryKey: ["group", query.groupId],
+    queryFn: () => fetcher(endpoint),
+    enabled: !!endpoint,
+  });
+
+  // Create a refetch function that can be passed to child components
+  const mutate = useCallback(() => {
+    refetch();
+  }, [refetch]);
 
   if (
     error &&


### PR DESCRIPTION
Replace SWR data fetching library with TanStack React Query for improved
developer experience, better TypeScript support, and enhanced devtools.

Changes:
- Install @tanstack/react-query and @tanstack/react-query-devtools
- Remove swr dependency
- Set up QueryClientProvider with default options in _app.tsx
- Migrate all useSWR hooks to useQuery in:
  * components/Gifts/GiftsList.tsx
  * components/Groups/GroupsList.tsx
  * pages/groups/[groupId].tsx
- Update all test files to mock React Query instead of SWR:
  * components/Gifts/GiftsList.test.tsx
  * components/Groups/GroupsList.test.tsx
- Add React Query DevTools for development
- All tests passing (194/194)