### PR TITLE
Make gift changes instantly visible in UI

### DIFF
--- a/components/Gifts/GiftsList.tsx
+++ b/components/Gifts/GiftsList.tsx
@@ -56,8 +56,9 @@ const GiftsList = ({ groupId, initialSearch }: GiftsListProps) => {
 
   // Create a refetch function that can be passed to child components
   const mutate = useCallback(() => {
-    refetch();
-  }, [refetch]);
+    // Invalidate queries to ensure the cache is properly refreshed
+    queryClient.invalidateQueries({ queryKey: ["gifts", groupId] });
+  }, [queryClient, groupId]);
 
   if (error) {
     return <p>Sorry. There was an error retrieving the gifts.</p>;
@@ -146,7 +147,7 @@ const GiftsList = ({ groupId, initialSearch }: GiftsListProps) => {
   useEffect(() => {
     if (!data || !data.gifts) return;
 
-    // Only reset gifts when data changes for the first time
+    // On initial load, handle initial search
     if (isInitialLoad) {
       setGifts(data.gifts);
       // Apply initial search if provided (skip URL update since it's already in URL)
@@ -154,8 +155,50 @@ const GiftsList = ({ groupId, initialSearch }: GiftsListProps) => {
         searchGifts({ search: initialSearch }, true);
       }
       setIsInitialLoad(false);
+    } else {
+      // On subsequent updates, refresh the gifts and reapply any active search
+      const activeSearch = router.query.s as string | undefined;
+      if (activeSearch) {
+        // Reapply the active search to the new data
+        const searchQuery = parseSearchQuery(activeSearch);
+        const filteredGifts = data.gifts.filter((gift) => {
+          if (searchQuery.type === "field-specific") {
+            switch (searchQuery.field) {
+              case "for":
+                return (
+                  gift.giftFor.name.toLowerCase().indexOf(searchQuery.value) > -1
+                );
+              case "name":
+                return gift.name.toLowerCase().indexOf(searchQuery.value) > -1;
+              case "description":
+                return (
+                  gift.description.toLowerCase().indexOf(searchQuery.value) > -1
+                );
+              case "url":
+                return gift.url.toLowerCase().indexOf(searchQuery.value) > -1;
+              case "price":
+                return (
+                  gift.price &&
+                  gift.price.toString().indexOf(searchQuery.value) > -1
+                );
+              default:
+                return false;
+            }
+          } else {
+            return (
+              gift.name.toLowerCase().indexOf(searchQuery.value) > -1 ||
+              gift.description.toLowerCase().indexOf(searchQuery.value) > -1 ||
+              gift.giftFor.name.toLowerCase().indexOf(searchQuery.value) > -1
+            );
+          }
+        });
+        setGifts(filteredGifts);
+      } else {
+        // No search active, just update with all gifts
+        setGifts(data.gifts);
+      }
     }
-  }, [data, initialSearch, searchGifts, isInitialLoad]);
+  }, [data, initialSearch, searchGifts, isInitialLoad, router.query.s]);
 
   const reset = (): void => {
     if (!data || !data.gifts) return;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
Changed the mutation callback to use queryClient.invalidateQueries() instead of refetch() for more reliable cache invalidation. Also updated the useEffect to refresh the gifts state whenever data changes (not just on initial load), while preserving any active search filters by reapplying them to the new data.

This ensures that when a gift is added, edited, or deleted, the change is immediately reflected in the UI.