### PR TITLE
Clear gift form inputs after successful submission

### DIFF
--- a/components/Gifts/CreateGift.tsx
+++ b/components/Gifts/CreateGift.tsx
@@ -67,7 +67,15 @@ const CreateGift = ({ updated }: CreateGiftProps) => {
         // If the form was submitted successfully, reset it so we can submit another and then
         // call the updated callback
         if (response.data && response.data.message === "Success") {
-          reset({});
+          // Reset all form fields to empty values while preserving the groupId
+          reset({
+            name: "",
+            description: "",
+            url: "",
+            giftFor: "",
+            price: "",
+            groupId: query.groupId as string,
+          });
           updated();
           setIsOpen(false); // Close the drawer on success
         } else if (response.error) {


### PR DESCRIPTION
Updated the CreateGift component to explicitly reset all form fields
(name, description, url, giftFor, price) to empty strings after a gift
is successfully submitted. This improves UX by allowing users to easily
add multiple gifts in succession without manually clearing the previous
gift's data. The groupId is preserved in the reset to maintain the
correct group context for subsequent submissions.